### PR TITLE
Update docs upload script to move kotlin-extensions into java directo…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,20 +232,10 @@ task javadoc(type:GradleBuild) {
     configure copyProperties
 }
 
-task createKotlinRootRedirectFile(type: Copy) {
-    description = 'Redirects from /kotlin/<version>/ to /kotlin/<version>/kotlin-extensions, which is the real root folder'
-    from 'realm/templates'
-    into "$buildDir/outputs/doc_redirects/kotlin_root"
-    include 'redirect.html.template'
-    rename { file -> 'index.html' }
-    expand(title: "Kotlin Extensions ${currentVersion}", url: "./kotlin-extensions/index.html")
-}
-
 task uploadJavadoc {
     group = 'Release'
     description = 'Upload Java and Kotlin docs to S3'
     dependsOn javadoc
-    dependsOn createKotlinRootRedirectFile
 
     doLast {
         def awsAccessKey = getPropertyValueOrThrow("SDK_DOCS_AWS_ACCESS_KEY")
@@ -262,14 +252,13 @@ task uploadJavadoc {
             exec {
                 commandLine 's3cmd', 'modify', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "--debug", '--add-header=Content-Type: text/css', "s3://realm-sdks/realm-sdks/java/${version}/stylesheet.css"
             }
+            // Dokka creates the stylesheet outside of the actual docs
+            // directory. When we upload the Dokka output into the java
+            // directory. kotlin-extensions's style.css will be placed at
+            // java/<version>/ (will not clobber javadoc's css, which is called
+            // stylesheet.css), while kotlin-extensions/ will be a subdirectory.
             exec {
-                commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/kotlin-extensions/build/docs/', "s3://realm-sdks/realm-sdks/kotlin/${version}/"
-            }
-
-            // Upload automatic redirect for Kotlin extensions, since the directory structure created
-            // by Dokka only have a style.css in the root dir.
-            exec {
-                commandLine 's3cmd', 'put', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", "$buildDir/outputs/doc_redirects/kotlin_root/index.html", "s3://realm-sdks/realm-sdks/kotlin/${version}/index.html"
+                commandLine 's3cmd', 'put', '--recursive', '--acl-public', "--access_key=${awsAccessKey}", "--secret_key=${awsSecretKey}", 'realm/kotlin-extensions/build/docs/', "s3://realm-sdks/realm-sdks/java/${version}/"
             }
         }
     }


### PR DESCRIPTION
…ry (#7507)

- Make room for Kotlin SDK to be at /realm-sdks/kotlin/
- Removed redirect logic, since it will no longer be required